### PR TITLE
disable bypass of launch_add_kinect_noise and gaussian_shifts

### DIFF
--- a/main_add_kinect_noise.cpp
+++ b/main_add_kinect_noise.cpp
@@ -471,7 +471,7 @@ int main(void)
                          tex_coords->height());
 
         iu::copy(noisy_depth_copy,h_noisy_depth);
-
+        iu::copy(h_noisy_depth,h_depth);
 
         float max_val = -1E10;
         float min_val =  1E10;


### PR DESCRIPTION
Hi Ankur,

In _main_add_kinect_noise.cpp_:
Noise added to depthmap with noise::launch_add_kinect_noise **(1)** and noise::gaussian_shifts **(2)** is stored in h_noisy_depth.
Then, you compute disparities **(3)** (before filterDisp **(4)** and Barron noise **(5)**) from h_depth. Actually, h_noisy_depth is just thrown away.

I just add following line to fix it:

> iu::copy(h_noisy_depth,h_depth);
